### PR TITLE
Migrate GitHub Actions Artifacts from v3 to v4 

### DIFF
--- a/analyze/action.yml
+++ b/analyze/action.yml
@@ -182,17 +182,20 @@ runs:
           fi
         fi
         echo "::endgroup::"
+    - name: Set artifact name
+      shell: bash
+      run: |
+        echo "ARTIFACT_NAME=${REPO_OWNER}-${REPO_NAME}" >> "$GITHUB_ENV"
     - name: Archive results
       if: env.SARIF_RESULTS_DOWNLOADED == 'true' || steps.analyze-codeql-db.outcome == 'success'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: cbom-results
+        name: ${{ env.ARTIFACT_NAME }}
         path: ${{ github.workspace }}/cbom-results
     - name: Upload results to Code Scanning
       if: |
         inputs.uploadToCodeScanning == 'true' &&
         (env.SARIF_RESULTS_DOWNLOADED == 'true' || steps.analyze-codeql-db.outcome == 'success')
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ env.SARIF_DIR_PATH }}/${{ env.GIT_SHA }}/${{ inputs.language }}.sarif
-

--- a/workflow-summary/action.yml
+++ b/workflow-summary/action.yml
@@ -4,9 +4,8 @@ runs:
   using: composite
   steps:
     - name: Unarchive results
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: cbom-results
         path: ${{ github.workspace }}/cbom-results
     - name: Post summary info
       shell: bash -ex {0}
@@ -20,6 +19,6 @@ runs:
         echo "|----------|---------|-----------|-------------|-----------------|" >> $GITHUB_STEP_SUMMARY
         shopt -s globstar
         jq -cn 'foreach inputs as $i (0; . +1; "\(input_filename|rtrimstr(".sarif"))/\($i.runs[].results|length)")' **/*.sarif \
-        | xargs -I "{}" bash -c 'IFS=/ read -r OWNER REPO COMMIT LANGUAGE RESULT_COUNT <<< {};
+        | xargs -I "{}" bash -c 'IFS=/ read -r ARTIFACT OWNER REPO COMMIT LANGUAGE RESULT_COUNT <<< {};
             echo "| ${OWNER} | ${REPO} | ${COMMIT} | ${LANGUAGE} | ${RESULT_COUNT} |" >> $GITHUB_STEP_SUMMARY'
         echo "::endgroup::"


### PR DESCRIPTION
### Migrate GitHub Actions Artifacts from v3 to v4  

As of **January 30, 2025**, [GitHub Actions Artifacts v3 has been deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/), rendering this tool unusable.  

This update migrates the workflow to use **Artifacts v4**, which includes the following changes:  

- Upgraded `actions/download-artifact@v3` → `actions/download-artifact@v4`  
- Upgraded `github/codeql-action/upload-sarif@v2` → `github/codeql-action/upload-sarif@v3`  
- Updated artifact naming convention:  
  - Artifacts must have unique names in v4, so they are now named based on their **repository owner and name**.  
  - All artifacts are saved in the `cbom-results` directory.  
  - The `summary_workflow` file now scans the `cbom-results` folder for all artifacts instead of relying on a single `"cbom-results"` artifact name.  

This ensures compatibility with the latest GitHub Actions updates and maintains the workflow's functionality.  
