### PR TITLE
Update upload/download Artefacts

### DIFF
--- a/analyze/action.yml
+++ b/analyze/action.yml
@@ -184,7 +184,7 @@ runs:
         echo "::endgroup::"
     - name: Archive results
       if: env.SARIF_RESULTS_DOWNLOADED == 'true' || steps.analyze-codeql-db.outcome == 'success'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cbom-results
         path: ${{ github.workspace }}/cbom-results

--- a/workflow-summary/action.yml
+++ b/workflow-summary/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Unarchive results
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: cbom-results
         path: ${{ github.workspace }}/cbom-results


### PR DESCRIPTION
Hello,

These scripts fail owing to the fact they use `actions/upload-artifact@v3` and `actions/download-artifact@v3`. This PR just updates these to v4 in a configuration that has worked during our testing :) 

**NB** - there's no other updating of any release tags for this repo itself; they're still `@v1`. 

Cheers! M.