### PR TITLE
Potential fix for code scanning alert no. 73: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/example-app.yml
+++ b/.github/workflows/example-app.yml
@@ -1,4 +1,6 @@
 name: Create Crypto Bill of Materials
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/cbom-action/security/code-scanning/73](https://github.com/advanced-security/cbom-action/security/code-scanning/73)

To fix this problem, you should add a `permissions` block either at the root of the workflow (which will apply to all jobs by default) or individually for each job. Since all jobs in the provided workflow are unlikely to need write access to repo contents, a minimal permissions block should be added, specifying `contents: read` at the workflow root level for maximal coverage and clarity. This follows GitHub's least privilege principle and aligns with security recommendations. The change should be made at the top of `.github/workflows/example-app.yml` immediately following the workflow `name` and before the `on:` block for standard practice. No external packages or additional resources are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
